### PR TITLE
Modify dist plan arguments for GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       - id: plan
         run: |
           if [ -n "${{ !github.event.pull_request && github.ref_name || '' }}" ]; then
-            dist ${{ format('host --steps=create --tag={0}', github.ref_name) }} --output-format=json > plan-dist-manifest.json
+            dist ${{ format('host --allow-dirty --steps=create --tag=axum-rails-cookie-{0}', github.ref_name) }} --output-format=json > plan-dist-manifest.json
             echo "dist ran successfully"
             cat plan-dist-manifest.json
             echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
In order to ensure that dist plan runs successfully for a created tag, this commit modifies the dist host command to include the crate name in the tag used and to allow-dirty since we have modified the release.yml from what cargo dist provides.