### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/endoze/axum-rails-cookie/compare/v0.1.1...v0.1.2) - 2024-11-13
+
+### Other
+
+- Modify dist plan arguments for GitHub release action
+
 ## [0.1.1](https://github.com/endoze/axum-rails-cookie/compare/v0.1.0...v0.1.1) - 2024-11-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "axum-rails-cookie"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-rails-cookie"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Extract rails session cookies in axum based apps."
 authors = ["Endoze <endoze@endozemedia.com>"]


### PR DESCRIPTION
## 🤖 New release
* `axum-rails-cookie`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/endoze/axum-rails-cookie/compare/v0.1.1...v0.1.2) - 2024-11-13

### Other

- Modify dist plan arguments for GitHub release action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).