### PR TITLE
Test release dist host command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.25.2-prerelease.3/cargo-dist-installer.sh | sh"
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist --rev a8077660fcae20ecda0e6709d6f42f0f542f5852 cargo-dist"
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -77,7 +80,6 @@ jobs:
       - id: plan
         run: |
           if [ -n "${{ !github.event.pull_request && github.ref_name || '' }}" ]; then
-            dist --version
             dist host --allow-dirty --steps=create ${{ format('--tag=axum-rails-cookie-{0}', github.ref_name) }} --output-format=json > plan-dist-manifest.json
             echo "dist ran successfully"
             cat plan-dist-manifest.json


### PR DESCRIPTION
In order to test the release github action workflow, this commit modifies it to run on pull requests instead of just tags.