### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/endoze/axum-rails-cookie/compare/v0.1.3...v0.1.4) - 2024-11-14
+
+### Other
+
+- Add usage of cache@v3 for dist binary build during release
+- Test release dist host command
+
 ## [0.1.3](https://github.com/endoze/axum-rails-cookie/compare/v0.1.2...v0.1.3) - 2024-11-13
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "axum-rails-cookie"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-rails-cookie"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Extract rails session cookies in axum based apps."
 authors = ["Endoze <endoze@endozemedia.com>"]


### PR DESCRIPTION
## 🤖 New release
* `axum-rails-cookie`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/endoze/axum-rails-cookie/compare/v0.1.3...v0.1.4) - 2024-11-14

### Other

- Add usage of cache@v3 for dist binary build during release
- Test release dist host command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).