### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/endoze/axum-rails-cookie/compare/v0.1.5...v0.1.6) - 2025-06-14
+
+### Other
+
+- Add keywords and categories for crates.io
+
 ## [0.1.5](https://github.com/endoze/axum-rails-cookie/compare/v0.1.4...v0.1.5) - 2025-05-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "axum-rails-cookie"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-rails-cookie"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 description = "Extract rails session cookies in axum based apps."
 authors = ["Endoze <endoze@endozemedia.com>"]


### PR DESCRIPTION



## 🤖 New release

* `axum-rails-cookie`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/endoze/axum-rails-cookie/compare/v0.1.5...v0.1.6) - 2025-06-14

### Other

- Add keywords and categories for crates.io
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).