### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/endoze/axum-rails-cookie/compare/v0.1.6...v0.1.7) - 2026-07-20
+
+### Other
+
+- move actions off deprecated Node runtimes, pin to SHAs
+- *(deps)* update dependencies and upgrade axum-extra to 0.12
+
 ## [0.1.6](https://github.com/endoze/axum-rails-cookie/compare/v0.1.5...v0.1.6) - 2025-06-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "axum-rails-cookie"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-rails-cookie"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 description = "Extract rails session cookies in axum based apps."
 authors = ["Endoze <endoze@endozemedia.com>"]


### PR DESCRIPTION



## 🤖 New release

* `axum-rails-cookie`: 0.1.6 -> 0.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/endoze/axum-rails-cookie/compare/v0.1.6...v0.1.7) - 2026-07-20

### Other

- move actions off deprecated Node runtimes, pin to SHAs
- *(deps)* update dependencies and upgrade axum-extra to 0.12
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).